### PR TITLE
feat: retry without arguments if no results where found

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # MCP Code Snippets
 
 This is an local adapter for MCP server that allows Agents to lookup code snippets in your project.
-Local MCP implementation allows to auto-fill some arguments for the remote MCP server, and therefore make lookup more accurate.
+Local MCP implementation allows to auto-fill some arguments for the remote MCP server, and therefore make lookup more accurate. If no results are found with these arguments, results without arguments are returned.
 By default, it uses Qdrant-maintaned remote MCP server with a collection of code snippets, but you can use your own collection by providing a custom MCP proxy configuration.
 
 ## Setup

--- a/mcp_code_snippets/main.py
+++ b/mcp_code_snippets/main.py
@@ -59,6 +59,14 @@ async def lookup_snippet(
             "qdrant-find",
             arguments=arguments,
         )
+
+        # If empty, try again without filters
+        if len(result) == 0:
+            result = await mcp.client.call_tool(
+                "qdrant-find",
+                arguments={"query": query},
+            )
+
         return result
 
 


### PR DESCRIPTION
`mcp-server-qdrant` now returns an empty results list if no results where found (ref https://github.com/qdrant/mcp-server-qdrant/pull/83). This can happen, if for example no package that is known to `mcp-for-docs` is listed as a project dependency. It is more intuitive to fall back to querying without language and package filters, if no results where found.